### PR TITLE
Fix requireUpperBoundDeps failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,15 +59,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.13</version>
       <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.6</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -79,6 +71,11 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <!-- provided by jackson2-api, pulled in transitively through promoted-builds -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
I was excited to see https://github.com/jenkinsci/plugin-usage-plugin/pull/27 upgrading the parent pom. I noticed the build is failing with `RequireUpperBoundDeps` issues. These changes worked for me locally, so I thought it might be helpful to send them over.

`matrix-project` has a version in the plugins bom.
`pipeline-model-definition` already brings in gson.